### PR TITLE
Made ShardingConfigurationSource class abstract

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Clustering support for PHP-LRPM, including different sharding strategies.
 
 == Usage
 
-You should extend abstract `PHPLRPM\Cluster\ShardingConfigurationSource` class and implement zero-arguments constructor which will be initializing instances of `PHPLRPM\ConfigurationSource`, `PHPLRPM\Cluster\Providers\ClusterConfigurationProvider` and `PHPLRPM\Cluster\Filters\ShardingConfigurationFilter`:
+You should extend the abstract `PHPLRPM\Cluster\ShardingConfigurationSource` class and implement a nullary (zero-argument) constructor which will be initializing instances of `PHPLRPM\ConfigurationSource`, `PHPLRPM\Cluster\Providers\ClusterConfigurationProvider` and `PHPLRPM\Cluster\Filters\ShardingConfigurationFilter`:
 
 [source,php]
 ----
@@ -25,12 +25,12 @@ class MyLRPMWorkerShardingConfiguration extends ShardingConfigurationSource
 }
 ----
 
-Then you can pass it to LRPM binary as an argument:
-
+Then you may provide MyLRPMWorkerShardingConfiguration as regular ConfigurationSource for PHP-LRPM, e.g.
 [source,console]
 ----
-bin/lrpm '\MyNamespace\MyLRPMWorkerShardingConfiguration'
+lrpm '\MyNamespace\MyLRPMWorkerShardingConfiguration'
 ----
+See https://github.com/vrza/php-lrpm#usage for more details.
 
 == Sharding Strategies
 

--- a/README.adoc
+++ b/README.adoc
@@ -8,14 +8,15 @@ You should extend abstract `PHPLRPM\Cluster\ShardingConfigurationSource` class a
 
 [source,php]
 ----
+namespace MyNamespace;
 use PHPLRPM\Cluster\ShardingConfigurationSource;
 
-class LRPMWorkerShardingConfiguration extends ShardingConfigurationSource
+class MyLRPMWorkerShardingConfiguration extends ShardingConfigurationSource
 {
     public function __construct()
     {
         //instance of PHPLRPM\ConfigurationSource
-        $this->confSource = new WorkerConfiguration()
+        $this->confSource = new MyLRPMWorkerConfiguration()
         //instance of PHPLRPM\Cluster\Providers\ClusterConfigurationProvider
         $this->clusterConfProvider = new EnvironmentBasedClusterConfigurationProvider();
         //instance of PHPLRPM\Cluster\Filters\ShardingConfigurationFilter
@@ -24,14 +25,11 @@ class LRPMWorkerShardingConfiguration extends ShardingConfigurationSource
 }
 ----
 
-Then you can use pass it to PHP-LRPM's ProcessManager as usual:
+Then you can pass it to LRPM binary as an argument:
 
-[source,php]
+[source,console]
 ----
-use PHPLRPM\ProcessManager;
-
-$pm = new ProcessManager(LRPMWorkerShardingConfiguration::class);
-$pm->run();
+bin/lrpm '\MyNamespace\MyLRPMWorkerShardingConfiguration'
 ----
 
 == Sharding Strategies

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ class MyLRPMWorkerShardingConfiguration extends ShardingConfigurationSource
 }
 ----
 
-Then you may provide MyLRPMWorkerShardingConfiguration as regular ConfigurationSource for PHP-LRPM, e.g.
+Then you may provide `MyLRPMWorkerShardingConfiguration` as a regular `ConfigurationSource` for PHP-LRPM, e.g.
 [source,console]
 ----
 lrpm '\MyNamespace\MyLRPMWorkerShardingConfiguration'

--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,38 @@
 
 Clustering support for PHP-LRPM, including different sharding strategies.
 
+== Usage
+
+You should extend abstract `PHPLRPM\Cluster\ShardingConfigurationSource` class and implement zero-arguments constructor which will be initializing instances of `PHPLRPM\ConfigurationSource`, `PHPLRPM\Cluster\Providers\ClusterConfigurationProvider` and `PHPLRPM\Cluster\Filters\ShardingConfigurationFilter`:
+
+[source,php]
+----
+use PHPLRPM\Cluster\ShardingConfigurationSource;
+
+class LRPMWorkerShardingConfiguration extends ShardingConfigurationSource
+{
+    public function __construct()
+    {
+        //instance of PHPLRPM\ConfigurationSource
+        $this->confSource = new WorkerConfiguration()
+        //instance of PHPLRPM\Cluster\Providers\ClusterConfigurationProvider
+        $this->clusterConfProvider = new EnvironmentBasedClusterConfigurationProvider();
+        //instance of PHPLRPM\Cluster\Filters\ShardingConfigurationFilter
+        $this->configurationFilter = new BalancedShardingConfigurationFilter();
+    }
+}
+----
+
+Then you can use pass it to PHP-LRPM's ProcessManager as usual:
+
+[source,php]
+----
+use PHPLRPM\ProcessManager;
+
+$pm = new ProcessManager(LRPMWorkerShardingConfiguration::class);
+$pm->run();
+----
+
 == Sharding Strategies
 
 You can either write your own `ShardingConfigurationFilter` or use one of the built-in filters.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "php-lrpm/php-lrpm": "dev-main",
+        "php-lrpm/php-lrpm": "dev-rename-deps",
         "php-rendezvous-hashing/php-rendezvous-hashing": "dev-main"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/vrza/php-tipc"
+            "url": "https://github.com/vrza/php-symplib"
         },
         {
             "type": "vcs",

--- a/src/Providers/EnvironmentBasedClusterConfigurationProvider.php
+++ b/src/Providers/EnvironmentBasedClusterConfigurationProvider.php
@@ -3,6 +3,7 @@
 namespace PHPLRPM\Cluster\Providers;
 
 use PHPLRPM\Cluster\ClusterConfiguration;
+use PHPLRPM\Cluster\Exceptions\ClusterConfigurationValidationException;
 
 class EnvironmentBasedClusterConfigurationProvider implements ClusterConfigurationProvider
 {
@@ -22,14 +23,14 @@ class EnvironmentBasedClusterConfigurationProvider implements ClusterConfigurati
 
     public function loadClusterConfiguration(): ClusterConfiguration
     {
-        $sInstanceNum = getenv($this->varInstanceNum) ?: 1;
+        $sInstanceNum = getenv($this->varInstanceNum) ?: '1';
         if (!ctype_digit($sInstanceNum)) {
             $errMsg = "Instance Number is not an integer value: {$this->varInstanceNum}={$sInstanceNum}";
             throw new ClusterConfigurationValidationException($errMsg);
         }
         $instanceNumber = intval($sInstanceNum);
 
-        $sNumOfInstances = getenv($this->varNumOfInstances) ?: 1;
+        $sNumOfInstances = getenv($this->varNumOfInstances) ?: '1';
         if (!ctype_digit($sNumOfInstances)) {
             $errMsg = "Number of instances is not an integer value: {$this->varNumOfInstances}={$sNumOfInstances}";
             throw new ClusterConfigurationValidationException($errMsg);

--- a/src/Providers/EnvironmentBasedClusterConfigurationProvider.php
+++ b/src/Providers/EnvironmentBasedClusterConfigurationProvider.php
@@ -22,14 +22,14 @@ class EnvironmentBasedClusterConfigurationProvider implements ClusterConfigurati
 
     public function loadClusterConfiguration(): ClusterConfiguration
     {
-        $sInstanceNum = getenv($this->varInstanceNum);
+        $sInstanceNum = getenv($this->varInstanceNum) ?: 1;
         if (!ctype_digit($sInstanceNum)) {
             $errMsg = "Instance Number is not an integer value: {$this->varInstanceNum}={$sInstanceNum}";
             throw new ClusterConfigurationValidationException($errMsg);
         }
         $instanceNumber = intval($sInstanceNum);
 
-        $sNumOfInstances = getenv($this->varNumOfInstances);
+        $sNumOfInstances = getenv($this->varNumOfInstances) ?: 1;
         if (!ctype_digit($sNumOfInstances)) {
             $errMsg = "Number of instances is not an integer value: {$this->varNumOfInstances}={$sNumOfInstances}";
             throw new ClusterConfigurationValidationException($errMsg);

--- a/src/Providers/EnvironmentBasedClusterConfigurationProvider.php
+++ b/src/Providers/EnvironmentBasedClusterConfigurationProvider.php
@@ -23,7 +23,7 @@ class EnvironmentBasedClusterConfigurationProvider implements ClusterConfigurati
 
     public function loadClusterConfiguration(): ClusterConfiguration
     {
-        $sInstanceNum = getenv($this->varInstanceNum) ?: '1';
+        $sInstanceNum = getenv($this->varInstanceNum) ?: '0';
         if (!ctype_digit($sInstanceNum)) {
             $errMsg = "Instance Number is not an integer value: {$this->varInstanceNum}={$sInstanceNum}";
             throw new ClusterConfigurationValidationException($errMsg);

--- a/src/ShardingConfigurationSource.php
+++ b/src/ShardingConfigurationSource.php
@@ -9,12 +9,14 @@ use RuntimeException;
 
 abstract class ShardingConfigurationSource implements ConfigurationSource
 {
-    private $confSource;
-    private $clusterConfProvider;
-    /**
-     * @var ShardingConfigurationFilter
-     */
-    private $configurationFilter;
+    /** @var ConfigurationSource */
+    protected $confSource;
+
+    /** @var ClusterConfigurationProvider */
+    protected $clusterConfProvider;
+
+    /** @var ShardingConfigurationFilter */
+    protected $configurationFilter;
 
     abstract public function __construct();
     /*

--- a/src/ShardingConfigurationSource.php
+++ b/src/ShardingConfigurationSource.php
@@ -19,13 +19,6 @@ abstract class ShardingConfigurationSource implements ConfigurationSource
     protected $configurationFilter;
 
     abstract public function __construct();
-    /*
-     {
-        $this->confSource = $confSource;
-        $this->clusterConfProvider = $clusterConfProvider;
-        $this->configurationFilter = $configurationFilter;
-     }
-     */
 
     public function loadConfiguration(): array
     {

--- a/src/ShardingConfigurationSource.php
+++ b/src/ShardingConfigurationSource.php
@@ -6,7 +6,7 @@ use PHPLRPM\Cluster\Filters\ShardingConfigurationFilter;
 use PHPLRPM\Cluster\Providers\ClusterConfigurationProvider;
 use PHPLRPM\ConfigurationSource;
 
-class ShardingConfigurationSource implements ConfigurationSource
+abstract class ShardingConfigurationSource implements ConfigurationSource
 {
     private $confSource;
     private $clusterConfProvider;
@@ -15,12 +15,14 @@ class ShardingConfigurationSource implements ConfigurationSource
      */
     private $configurationFilter;
 
-    public function __construct(ConfigurationSource $confSource, ClusterConfigurationProvider $clusterConfProvider, ShardingConfigurationFilter $configurationFilter)
-    {
+    abstract public function __construct();
+    /*
+     {
         $this->confSource = $confSource;
         $this->clusterConfProvider = $clusterConfProvider;
         $this->configurationFilter = $configurationFilter;
-    }
+     }
+     */
 
     public function loadConfiguration(): array
     {

--- a/src/ShardingConfigurationSource.php
+++ b/src/ShardingConfigurationSource.php
@@ -5,6 +5,7 @@ namespace PHPLRPM\Cluster;
 use PHPLRPM\Cluster\Filters\ShardingConfigurationFilter;
 use PHPLRPM\Cluster\Providers\ClusterConfigurationProvider;
 use PHPLRPM\ConfigurationSource;
+use RuntimeException;
 
 abstract class ShardingConfigurationSource implements ConfigurationSource
 {
@@ -26,6 +27,7 @@ abstract class ShardingConfigurationSource implements ConfigurationSource
 
     public function loadConfiguration(): array
     {
+        $this->validateInitializedProperties();
         $inputConfig = $this->confSource->loadConfiguration();
         $clusterConfig = $this->clusterConfProvider->loadClusterConfiguration();
         return $this->filterConfig($inputConfig, $clusterConfig);
@@ -34,5 +36,32 @@ abstract class ShardingConfigurationSource implements ConfigurationSource
     private function filterConfig(array $inputConfig, ClusterConfiguration $clusterConf): array
     {
         return $this->configurationFilter->filterConfig($inputConfig, $clusterConf);
+    }
+
+    private function validateInitializedProperties(): void
+    {
+        if (!(isset($this->confSource))
+            || !($this->confSource instanceof ConfigurationSource)
+        ) {
+            throw new RuntimeException(
+                'ShardingConfigurationSource::confSource must be initialized and implement ConfigurationSource'
+            );
+        }
+
+        if (!(isset($this->clusterConfProvider))
+            || !($this->clusterConfProvider instanceof ClusterConfigurationProvider)
+        ) {
+            throw new RuntimeException(
+                'ShardingConfigurationSource::clusterConfProvider must be initialized and implement ClusterConfigurationProvider'
+            );
+        }
+
+        if (!(isset($this->configurationFilter))
+            || !($this->configurationFilter instanceof ShardingConfigurationFilter)
+        ) {
+            throw new RuntimeException(
+                'ShardingConfigurationSource::configurationFilter must be initialized and implement ShardingConfigurationFilter'
+            );
+        }
     }
 }


### PR DESCRIPTION
Abstract constructor should be overriden by the user, as LRPM's ProcessManager constructor signature accepts class-string instead of an object.